### PR TITLE
Step6

### DIFF
--- a/src/main/java/domain/figure/AreaCalculable.java
+++ b/src/main/java/domain/figure/AreaCalculable.java
@@ -1,0 +1,10 @@
+package domain.figure;
+
+import java.util.List;
+
+public interface AreaCalculable {
+
+    double calcArea();
+
+    List<Double> getSidesLength();
+}

--- a/src/main/java/domain/figure/Figure.java
+++ b/src/main/java/domain/figure/Figure.java
@@ -1,11 +1,5 @@
 package domain.figure;
 
-import java.util.List;
-
-public interface Figure {
-    double calcArea();
-
-    List<Double> getSidesLength();
-
-    String getFigureName();
+public abstract class Figure implements AreaCalculable {
+    public abstract String getFigureName();
 }

--- a/src/main/java/domain/figure/Rectangle.java
+++ b/src/main/java/domain/figure/Rectangle.java
@@ -6,7 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
-public class Rectangle implements Figure {
+public class Rectangle extends Figure {
     public static final int VALID_COORDINATE_NUM = 4;
     private List<Point> points;
 

--- a/src/main/java/domain/figure/Triangle.java
+++ b/src/main/java/domain/figure/Triangle.java
@@ -6,7 +6,7 @@ import domain.point.Point;
 import java.util.ArrayList;
 import java.util.List;
 
-public class Triangle implements Figure {
+public class Triangle extends Figure {
     public static final int VALID_COORDINATE_NUM = 3;
     private List<Point> points;
 

--- a/src/test/java/domain/figure/RectangleTest.java
+++ b/src/test/java/domain/figure/RectangleTest.java
@@ -40,4 +40,9 @@ public class RectangleTest {
     public void 인스턴스_피규어_할당가능할까() {
         assertEquals(true, rect instanceof Figure);
     }
+
+    @Test
+    public void 인스턴스_넓이_구할수있을까() {
+        assertEquals(true, rect instanceof AreaCalculable);
+    }
 }

--- a/src/test/java/domain/figure/TriangleTest.java
+++ b/src/test/java/domain/figure/TriangleTest.java
@@ -4,11 +4,10 @@ import domain.point.Point;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class TriangleTest {
     private Triangle triangle;
@@ -27,5 +26,10 @@ public class TriangleTest {
     @Test
     public void 인스턴스_피규어_할당가능할까() {
         assertEquals(true, triangle instanceof Figure);
+    }
+
+    @Test
+    public void 인스턴스_넓이_구할수있을까() {
+        assertEquals(true, triangle instanceof AreaCalculable);
     }
 }


### PR DESCRIPTION
## 구현 내용
1. Figure와 AreaCalculable 나누어보았습니다.
- Figure가 AreaCalculable을 구현하도록 구조 변경
- 면적을 구할 수 있는 이라는 것을 명시적으로 나타내기 위함, 따로 관리하면 좋다는 생각(도형 관련 코드가 늘어났을 때)